### PR TITLE
Add project to group and project/group to user access levels

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -80,31 +80,38 @@ https://github.com/JupiterOne/sdk/blob/main/docs/integrations/development.md
 
 The following entities are created:
 
-| Resources     | Entity `_type`         | Entity `_class`       |
-| ------------- | ---------------------- | --------------------- |
-| Account       | `gitlab_account`       | `Account`             |
-| Commit        | `gitlab_commit`        | `CodeCommit`          |
-| Group         | `gitlab_group`         | `Group`               |
-| Merge Request | `gitlab_merge_request` | `CodeReview`, `PR`    |
-| Project       | `gitlab_project`       | `CodeRepo`, `Project` |
-| User          | `gitlab_user`          | `User`                |
+| Resources         | Entity `_type`             | Entity `_class`       |
+| ----------------- | -------------------------- | --------------------- |
+| Account           | `gitlab_account`           | `Account`             |
+| Commit            | `gitlab_commit`            | `CodeCommit`          |
+| Group             | `gitlab_group`             | `Group`               |
+| Group Access Role | `gitlab_group_access_role` | `AccessRole`          |
+| Merge Request     | `gitlab_merge_request`     | `CodeReview`, `PR`    |
+| Project           | `gitlab_project`           | `CodeRepo`, `Project` |
+| User              | `gitlab_user`              | `User`                |
+| User Access Role  | `gitlab_user_access_role`  | `AccessRole`          |
 
 ### Relationships
 
 The following relationships are created:
 
-| Source Entity `_type`  | Relationship `_class` | Target Entity `_type`  |
-| ---------------------- | --------------------- | ---------------------- |
-| `gitlab_account`       | **HAS**               | `gitlab_group`         |
-| `gitlab_account`       | **HAS**               | `gitlab_project`       |
-| `gitlab_group`         | **HAS**               | `gitlab_group`         |
-| `gitlab_group`         | **HAS**               | `gitlab_project`       |
-| `gitlab_group`         | **HAS**               | `gitlab_user`          |
-| `gitlab_merge_request` | **HAS**               | `gitlab_commit`        |
-| `gitlab_project`       | **HAS**               | `gitlab_merge_request` |
-| `gitlab_project`       | **HAS**               | `gitlab_user`          |
-| `gitlab_user`          | **APPROVED**          | `gitlab_merge_request` |
-| `gitlab_user`          | **OPENED**            | `gitlab_merge_request` |
+| Source Entity `_type`      | Relationship `_class` | Target Entity `_type`      |
+| -------------------------- | --------------------- | -------------------------- |
+| `gitlab_account`           | **HAS**               | `gitlab_group`             |
+| `gitlab_account`           | **HAS**               | `gitlab_project`           |
+| `gitlab_group_access_role` | **ALLOWS**            | `gitlab_group`             |
+| `gitlab_group`             | **HAS**               | `gitlab_group`             |
+| `gitlab_group`             | **HAS**               | `gitlab_project`           |
+| `gitlab_group`             | **HAS**               | `gitlab_user`              |
+| `gitlab_group`             | **HAS**               | `gitlab_user_access_role`  |
+| `gitlab_merge_request`     | **HAS**               | `gitlab_commit`            |
+| `gitlab_project`           | **HAS**               | `gitlab_group_access_role` |
+| `gitlab_project`           | **HAS**               | `gitlab_merge_request`     |
+| `gitlab_project`           | **HAS**               | `gitlab_user`              |
+| `gitlab_project`           | **HAS**               | `gitlab_user_access_role`  |
+| `gitlab_user_access_role`  | **ALLOWS**            | `gitlab_user`              |
+| `gitlab_user`              | **APPROVED**          | `gitlab_merge_request`     |
+| `gitlab_user`              | **OPENED**            | `gitlab_merge_request`     |
 
 <!--
 ********************************************************************************

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,8 @@ export const Steps = {
   PROJECTS: 'fetch-projects',
   MERGE_REQUESTS: 'fetch-merge-requests',
   COMMITS: 'fetch-mr-commits',
+  USER_ACCESS_ROLES: 'fetch-user-access-roles',
+  GROUP_ACCESS_ROLES: 'fetch-group-access-roles',
   BUILD_ACCOUNT_HAS_PROJECT: 'build-account-project-relationships',
   BUILD_ACCOUNT_HAS_GROUP: 'build-account-group-relationships',
   BUILD_PROJECT_HAS_USER: 'build-project-user-relationships',
@@ -16,6 +18,10 @@ export const Steps = {
   BUILD_PROJECT_HAS_PR: 'build-project-merge-request-relationships',
   BUILD_USER_OPENED_PR: 'build-user-opened-merge-request-relationships',
   BUILD_USER_APPROVED_PR: 'build-user-approved-merge-request-relationships',
+  BUILD_USER_ACCESS_ROLE_ALLOWS_USER:
+    'build-user-access-role-allows-user-relationships',
+  BUILD_GROUP_ACCESS_ROLE_ALLOWS_USER:
+    'build-group-access-role-allows-group-relationships',
 };
 
 export const Entities = {
@@ -49,6 +55,16 @@ export const Entities = {
     _type: 'gitlab_project',
     _class: ['CodeRepo', 'Project'],
   },
+  USER_ACCESS_ROLE: {
+    resourceName: 'User Access Role',
+    _type: 'gitlab_user_access_role',
+    _class: ['AccessRole'],
+  },
+  GROUP_ACCESS_ROLE: {
+    resourceName: 'Group Access Role',
+    _type: 'gitlab_group_access_role',
+    _class: ['AccessRole'],
+  },
 };
 
 export const Relationships = {
@@ -70,6 +86,18 @@ export const Relationships = {
     _class: RelationshipClass.HAS,
     targetType: Entities.USER._type,
   },
+  PROJECT_HAS_USER_ACCESS_ROLE: {
+    _type: 'gitlab_project_has_user_access_role',
+    sourceType: Entities.PROJECT._type,
+    _class: RelationshipClass.HAS,
+    targetType: Entities.USER_ACCESS_ROLE._type,
+  },
+  PROJECT_HAS_GROUP_ACCESS_ROLE: {
+    _type: 'gitlab_project_has_group_access_role',
+    sourceType: Entities.PROJECT._type,
+    _class: RelationshipClass.HAS,
+    targetType: Entities.GROUP_ACCESS_ROLE._type,
+  },
   GROUP_HAS_SUBGROUP: {
     _type: 'gitlab_group_has_group',
     sourceType: Entities.GROUP._type,
@@ -87,6 +115,12 @@ export const Relationships = {
     sourceType: Entities.GROUP._type,
     _class: RelationshipClass.HAS,
     targetType: Entities.PROJECT._type,
+  },
+  GROUP_HAS_USER_ACCESS_ROLE: {
+    _type: 'gitlab_group_has_user_access_role',
+    sourceType: Entities.GROUP._type,
+    _class: RelationshipClass.HAS,
+    targetType: Entities.USER_ACCESS_ROLE._type,
   },
   PROJECT_HAS_PR: {
     _type: 'gitlab_project_has_merge_request',
@@ -111,5 +145,17 @@ export const Relationships = {
     sourceType: Entities.MERGE_REQUEST._type,
     _class: RelationshipClass.HAS,
     targetType: Entities.COMMIT._type,
+  },
+  USER_ACCESS_ROLE_ALLOWS_USER: {
+    _type: 'gitlab_user_access_role_allows_user',
+    sourceType: Entities.USER_ACCESS_ROLE._type,
+    _class: RelationshipClass.ALLOWS,
+    targetType: Entities.USER._type,
+  },
+  GROUP_ACCESS_ROLE_ALLOWS_GROUP: {
+    _type: 'gitlab_group_access_role_allows_group',
+    sourceType: Entities.GROUP_ACCESS_ROLE._type,
+    _class: RelationshipClass.ALLOWS,
+    targetType: Entities.GROUP._type,
   },
 };

--- a/src/provider/GitlabClient.ts
+++ b/src/provider/GitlabClient.ts
@@ -25,10 +25,7 @@ import {
 const ITEMS_PER_PAGE = 100;
 
 export type ResourceIteratee<T> = (each: T) => Promise<void> | void;
-export type PageErrorHandler = ({
-  err: Error,
-  endpoint: string,
-}) => Promise<void> | void;
+export type PageErrorHandler = ({ err, endpoint }) => Promise<void> | void;
 
 export type RateLimitStatus = {
   limit: number;
@@ -133,17 +130,29 @@ export class GitlabClient {
   }
 
   async fetchProjectMembers(projectId: number): Promise<GitLabUserRef[]> {
-    return this.makePaginatedRequest(
-      HttpMethod.GET,
-      `/projects/${projectId}/members/all`,
-    );
+    let projectMembers;
+    try {
+      projectMembers = await this.makePaginatedRequest(
+        HttpMethod.GET,
+        `/projects/${projectId}/members/all`,
+      );
+    } catch (err) {
+      projectMembers = [];
+    }
+    return projectMembers;
   }
 
   async fetchGroupMembers(groupId: number): Promise<GitLabUserRef[]> {
-    return this.makePaginatedRequest(
-      HttpMethod.GET,
-      `/groups/${groupId}/members/all`,
-    );
+    let groupMembers;
+    try {
+      groupMembers = await this.makePaginatedRequest(
+        HttpMethod.GET,
+        `/groups/${groupId}/members/all`,
+      );
+    } catch (err) {
+      if (err.status === 403) groupMembers = [];
+    }
+    return groupMembers;
   }
 
   async fetchGroupSubgroups(groupId: number): Promise<GitLabGroup[]> {

--- a/src/provider/types.ts
+++ b/src/provider/types.ts
@@ -1,5 +1,15 @@
 import { Opaque } from 'type-fest';
 
+export enum AccessLevel {
+  NO_ACCESS = 'no access',
+  MINIMAL_ACCESS = 'minimal access',
+  GUEST = 'guest',
+  REPORTER = 'reporter',
+  DEVELOPER = 'developer',
+  MAINTAINER = 'maintainer',
+  OWNER = 'owner',
+}
+
 export interface GitLabUser {
   id: number;
   name: string;
@@ -23,7 +33,20 @@ export interface GitLabUserRef {
   name: string;
   username: string;
   state: string;
+  avatar_url: string;
+  web_url: string;
   access_level: number;
+  created_at: string;
+  expires_at: string | null;
+  membership_state: string;
+}
+
+export interface GitLabGroupRef {
+  group_id: number;
+  group_name: string;
+  group_full_path: string;
+  group_access_level: number;
+  expires_at: string | null;
 }
 
 export interface GitLabGroup {

--- a/src/steps/group-roles.ts
+++ b/src/steps/group-roles.ts
@@ -1,0 +1,95 @@
+import {
+  IntegrationStep,
+  IntegrationStepExecutionContext,
+  createDirectRelationship,
+  getRawData,
+} from '@jupiterone/integration-sdk-core';
+
+import { GitlabIntegrationConfig } from '../types';
+import { Entities, Relationships, Steps } from '../constants';
+import { createGroupAccessRoleEntity } from '../converters';
+import { GitLabGroupRef, GitLabProject } from '../provider/types';
+import { createGroupEntityIdentifier } from './fetch-groups';
+
+async function fetchGroupAccessRoles({
+  jobState,
+  logger,
+}: IntegrationStepExecutionContext<GitlabIntegrationConfig>) {
+  await jobState.iterateEntities(
+    { _type: Entities.PROJECT._type },
+    async (project) => {
+      const projectData = getRawData<GitLabProject>(project);
+      if (!projectData) {
+        logger.warn(
+          { _key: project._key },
+          'Raw data does not exist for project.',
+        );
+        return;
+      }
+      const { id, shared_with_groups } = projectData;
+      const groupRefs: GitLabGroupRef[] = shared_with_groups as GitLabGroupRef[];
+      const groupAccessRoleEntities = groupRefs.map(
+        createGroupAccessRoleEntity(id as number),
+      );
+      await jobState.addEntities(groupAccessRoleEntities);
+      await jobState.addRelationships(
+        groupAccessRoleEntities.map((entity) =>
+          createDirectRelationship({
+            from: project,
+            to: entity,
+            _class: Relationships.PROJECT_HAS_GROUP_ACCESS_ROLE._class,
+          }),
+        ),
+      );
+    },
+  );
+}
+
+async function buildGroupAccessRoleAllowsGroup({
+  jobState,
+  logger,
+}: IntegrationStepExecutionContext<GitlabIntegrationConfig>) {
+  await jobState.iterateEntities(
+    { _type: Entities.GROUP_ACCESS_ROLE._type },
+    async (groupAccessRole) => {
+      const groupAccessRoleData = getRawData<GitLabGroupRef>(groupAccessRole);
+      if (!groupAccessRoleData) {
+        logger.warn(
+          { _key: groupAccessRole._key },
+          'Raw data does not exist for group access role.',
+        );
+        return;
+      }
+      const groupEntity = await jobState.findEntity(
+        createGroupEntityIdentifier(groupAccessRoleData.group_id),
+      );
+      if (!groupEntity) return;
+      await jobState.addRelationship(
+        createDirectRelationship({
+          from: groupAccessRole,
+          to: groupEntity,
+          _class: Relationships.GROUP_ACCESS_ROLE_ALLOWS_GROUP._class,
+        }),
+      );
+    },
+  );
+}
+
+export const groupAccessRoleSteps: IntegrationStep<GitlabIntegrationConfig>[] = [
+  {
+    id: Steps.GROUP_ACCESS_ROLES,
+    name: 'Fetch group access roles',
+    entities: [Entities.GROUP_ACCESS_ROLE],
+    relationships: [Relationships.PROJECT_HAS_GROUP_ACCESS_ROLE],
+    executionHandler: fetchGroupAccessRoles,
+    dependsOn: [Steps.PROJECTS],
+  },
+  {
+    id: Steps.BUILD_GROUP_ACCESS_ROLE_ALLOWS_USER,
+    name: 'Build group access role allows user relationships',
+    entities: [],
+    relationships: [Relationships.GROUP_ACCESS_ROLE_ALLOWS_GROUP],
+    executionHandler: buildGroupAccessRoleAllowsGroup,
+    dependsOn: [Steps.GROUP_ACCESS_ROLES, Steps.USERS],
+  },
+];

--- a/src/steps/index.ts
+++ b/src/steps/index.ts
@@ -13,6 +13,8 @@ import projectUserStep from './build-project-user-relationships';
 import userOpenedMergeRequestStep from './build-user-opened-merge-request-relationships';
 import accountStep from './fetch-accounts';
 import groupStep from './fetch-groups';
+import { userAccessRoleSteps } from './user-roles';
+import { groupAccessRoleSteps } from './group-roles';
 import { mergeRequestSteps } from './merge-requests';
 import { projectSteps } from './projects';
 import { userSteps } from './users';
@@ -25,6 +27,8 @@ const integrationSteps: Step<
   groupStep,
   ...projectSteps,
   ...userSteps,
+  ...userAccessRoleSteps,
+  ...groupAccessRoleSteps,
   projectUserStep,
   accountGroupStep,
   accountProjectStep,

--- a/src/steps/user-roles.ts
+++ b/src/steps/user-roles.ts
@@ -1,0 +1,126 @@
+import {
+  IntegrationStep,
+  IntegrationStepExecutionContext,
+  createDirectRelationship,
+  getRawData,
+} from '@jupiterone/integration-sdk-core';
+
+import { createGitlabClient } from '../provider';
+import { GitlabIntegrationConfig } from '../types';
+import { Entities, Relationships, Steps } from '../constants';
+import {
+  createUserAccessRoleEntity,
+  createUserEntityIdentifier,
+} from '../converters';
+import { GitLabGroup, GitLabProject, GitLabUserRef } from '../provider/types';
+
+async function fetchUserAccessRoles({
+  instance,
+  jobState,
+  logger,
+}: IntegrationStepExecutionContext<GitlabIntegrationConfig>) {
+  const client = createGitlabClient(instance.config, logger);
+  await jobState.iterateEntities(
+    { _type: Entities.GROUP._type },
+    async (group) => {
+      const groupData = getRawData<GitLabGroup>(group);
+      if (!groupData) {
+        logger.warn({ _key: group._key }, 'Raw data does not exist for group.');
+        return;
+      }
+      const members = await client.fetchGroupMembers(groupData.id);
+      const userAccessRoleEntities = members.map(
+        createUserAccessRoleEntity(`group:${groupData.id}`),
+      );
+      await jobState.addEntities(userAccessRoleEntities);
+      await jobState.addRelationships(
+        userAccessRoleEntities.map((entity) =>
+          createDirectRelationship({
+            from: group,
+            to: entity,
+            _class: Relationships.GROUP_HAS_USER_ACCESS_ROLE._class,
+          }),
+        ),
+      );
+    },
+  );
+  await jobState.iterateEntities(
+    { _type: Entities.PROJECT._type },
+    async (project) => {
+      const projectData = getRawData<GitLabProject>(project);
+      if (!projectData) {
+        logger.warn(
+          { _key: project._key },
+          'Raw data does not exist for project.',
+        );
+        return;
+      }
+      const members = await client.fetchProjectMembers(projectData.id);
+      const userAccessRoleEntities = members.map(
+        createUserAccessRoleEntity(`project:${projectData.id}`),
+      );
+      await jobState.addEntities(userAccessRoleEntities);
+      await jobState.addRelationships(
+        userAccessRoleEntities.map((entity) =>
+          createDirectRelationship({
+            from: project,
+            to: entity,
+            _class: Relationships.PROJECT_HAS_USER_ACCESS_ROLE._class,
+          }),
+        ),
+      );
+    },
+  );
+}
+
+async function buildUserAccessRoleAllowsUser({
+  jobState,
+  logger,
+}: IntegrationStepExecutionContext<GitlabIntegrationConfig>) {
+  await jobState.iterateEntities(
+    { _type: Entities.USER_ACCESS_ROLE._type },
+    async (userAccessRole) => {
+      const userAccessRoleData = getRawData<GitLabUserRef>(userAccessRole);
+      if (!userAccessRoleData) {
+        logger.warn(
+          { _key: userAccessRole._key },
+          'Raw data does not exist for user access role.',
+        );
+        return;
+      }
+      const userEntity = await jobState.findEntity(
+        createUserEntityIdentifier(userAccessRoleData.id),
+      );
+      if (!userEntity) return;
+      await jobState.addRelationship(
+        createDirectRelationship({
+          from: userAccessRole,
+          to: userEntity,
+          _class: Relationships.USER_ACCESS_ROLE_ALLOWS_USER._class,
+        }),
+      );
+    },
+  );
+}
+
+export const userAccessRoleSteps: IntegrationStep<GitlabIntegrationConfig>[] = [
+  {
+    id: Steps.USER_ACCESS_ROLES,
+    name: 'Fetch user access roles',
+    entities: [Entities.USER_ACCESS_ROLE],
+    relationships: [
+      Relationships.GROUP_HAS_USER_ACCESS_ROLE,
+      Relationships.PROJECT_HAS_USER_ACCESS_ROLE,
+    ],
+    executionHandler: fetchUserAccessRoles,
+    dependsOn: [Steps.PROJECTS, Steps.GROUPS],
+  },
+  {
+    id: Steps.BUILD_USER_ACCESS_ROLE_ALLOWS_USER,
+    name: 'Build user access role allows user relationships',
+    entities: [],
+    relationships: [Relationships.USER_ACCESS_ROLE_ALLOWS_USER],
+    executionHandler: buildUserAccessRoleAllowsUser,
+    dependsOn: [Steps.USER_ACCESS_ROLES, Steps.USERS],
+  },
+];

--- a/src/util/getAccessLevel.ts
+++ b/src/util/getAccessLevel.ts
@@ -1,0 +1,21 @@
+import { AccessLevel } from '../provider/types';
+
+export const getAccessLevel = (numericAccessLevel: number) => {
+  switch (numericAccessLevel) {
+    case 50:
+      return AccessLevel.OWNER;
+    case 40:
+      return AccessLevel.MAINTAINER;
+    case 30:
+      return AccessLevel.DEVELOPER;
+    case 20:
+      return AccessLevel.REPORTER;
+    case 10:
+      return AccessLevel.GUEST;
+    case 5:
+      return AccessLevel.MINIMAL_ACCESS;
+    case 0:
+    default:
+      return AccessLevel.NO_ACCESS;
+  }
+};


### PR DESCRIPTION
# Description

_**Notes**_
- Projects can be shared to multiple groups, and groups can have several 'shared' projects.
- Groups contain access level information per user, but these can also be set on a per project basis.
- Access level information (numeric access level, access level, etc.) were stored as separate entities instead and connected to role holder and permission source.
  - `Project` > `HAS` > `UserAccessRole` and `AccessRole` > `ALLOWS` > `User`
  - `Group` > `HAS` > `UserAccessRole` and `AccessRole` > `ALLOWS` > `User`
  - `Project` > `HAS` > `GroupAccessRole` and `GroupAccessRole` > `ALLOWS` > `Group`

## Summary

<!-- Summary here! -->

## Type of change

Please leave any irrelevant options unchecked.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

### General Development Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Integration Development Checklist:

Please leave any irrelevant options unchecked.

- [x] I have checked for additional permissions required to call any new API
      endpoints, and have documented any additional permissions in
      `jupiterone.md`, where necessary.
- [x] My changes properly paginate the target service provider's API
- [x] My changes properly handle rate limiting of the target service provider's
      API
- [x] My new integration step is instrumented to execute in the correct order
      using `dependsOn`
- [x] I have referred to the
      [JupiterOne data model](https://github.com/JupiterOne/data-model/tree/main/src/schemas)
      to ensure that any new entities/relationships, and relevant properties,
      match the recommended model for this class of data
- [x] I have updated the `CHANGELOG.md` file to describe my changes
- [x] When changes include modifications to existing graph data ingestion, I've
      reviewed all existing managed questions referencing the entities,
      relationships, and their property names, to ensure those questions still
      function with my changes.
