### PR TITLE
[Fix] users 429 error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Changed
+
+- Changed the users fetching to be sequential as a solution for the rate
+  limiting issue.
+
 ## 4.4.0 - 2022-11-01
 
 ## Added

--- a/src/steps/users.ts
+++ b/src/steps/users.ts
@@ -42,9 +42,12 @@ export async function fetchUsers({
     },
   );
 
-  const users: GitLabUser[] = await Promise.all(
-    Object.values(usersMap).map((userRef) => client.fetchUser(userRef.id)),
-  );
+  const users: GitLabUser[] = [];
+
+  for (const userRef of Object.values(usersMap)) {
+    const userDetails = await client.fetchUser(userRef.id);
+    users.push(userDetails);
+  }
 
   await jobState.addEntities(users.map(createUserEntity));
 }


### PR DESCRIPTION
### Description
```
Step "Fetch users" failed to complete due to error. (errorCode="PROVIDER_API_ERROR", errorId="abb46c5a-8584-4e2a-b250-b08410b1649c", reason="Provider API failed at https://gitlab.com/api/v4/users/4192935: 429 Too Many Requests")
```
### RCA
- Bug is not directly reproducible due to lack of data
- It is hypothesized that something is causing the program to exceed rate limit of **[2000 API calls per minute](https://docs.gitlab.com/ee/user/gitlab_com/index.html#gitlabcom-specific-rate-limits)**, despite the 10% sleep buffer, when concurrently running requests via `Promise.all`
- Suggestion is to run the user requests sequentially instead to prevent the `429 error` from reoccuring.